### PR TITLE
install packer in chocolatey package dir

### DIFF
--- a/packer/packer.nuspec
+++ b/packer/packer.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>packer</id>
-    <version>0.7.5</version>
+    <version>0.7.5.20150603</version>
     <title>Packer</title>
     <authors>Mitchell Hashimoto, Jack Pearkes, Mark Peek, Ross Smith II, Rickard von Essen</authors>
     <owners>Stefan Scherer</owners>

--- a/packer/tools/chocolateyInstall.ps1
+++ b/packer/tools/chocolateyInstall.ps1
@@ -1,25 +1,14 @@
 $url = 'https://dl.bintray.com/mitchellh/packer/packer_0.7.5_windows_386.zip'
+$checksum = '4223a8e76eed0f8ad22a24b68495c37d85a334c7'
 $url64bit = 'https://dl.bintray.com/mitchellh/packer/packer_0.7.5_windows_amd64.zip'
-$unzipLocation = "$env:SystemDrive\HashiCorp\packer"
+$checksum64 = '4d5db9c33e471729561cd9a83ae3024b34b2d934'
+$legacyLocation = "$env:SystemDrive\HashiCorp\packer"
+$unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$packerExe = $unzipLocation + "\packer.exe"
-$packerPackerExe = $unzipLocation + "\packer-packer.exe"
+Install-ChocolateyZipPackage "packer" "$url" "$unzipLocation" "$url64bit" `
+ -checksum $checksum -checksumType 'sha1' -checksum64 $checksum64
 
-If (Test-Path $packerExe) {
-  Write-Host "Removing old $packerExe"
-  Remove-Item $packerExe
-}
-If (Test-Path $packerPackerExe) {
-  Write-Host "Removing old $packerPackerExe"
-  Remove-Item "$packerPackerExe"
-}
-
-Install-ChocolateyZipPackage "packer" "$url" "$unzipLocation" "$url64bit"
-Install-ChocolateyPath $unzipLocation
-
-If (-Not (Test-Path $packerExe)) {
-  If (Test-Path "$packerPackerExe") {
-    Write-Host "Copying $packerPackerExe to packer.exe"
-    Copy-Item -Path "$packerPackerExe" -Destination $packerExe
-  }
+If (Test-Path $legacyLocation) {
+  Write-Host "Removing old packer installation from $legacyLocation"
+  Remove-Item $legacyLocation -Force -Recurse
 }


### PR DESCRIPTION
Install packer into Chocolatey package dir, so Chocolatey is able to shim all exe files and put them into PATH automatically.
Chocolatey also can uninstall packer with this change.

Remove old files from `C:\HashiCorp\packer` if they exist.
