### PR TITLE
Install packer plugin in APPDATA

### DIFF
--- a/packer-post-processor-vagrant-vmware-ovf/packer-post-processor-vagrant-vmware-ovf.nuspec
+++ b/packer-post-processor-vagrant-vmware-ovf/packer-post-processor-vagrant-vmware-ovf.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>packer-post-processor-vagrant-vmware-ovf</id>
-    <version>0.2.1</version>
+    <version>0.2.1.20150603</version>
     <title>packer-post-processor-vagrant-vmware-ovf</title>
     <authors>Fabio Rapposelli, Stefan Scherer</authors>
     <owners>Stefan Scherer</owners>

--- a/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyInstall.ps1
+++ b/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyInstall.ps1
@@ -1,6 +1,13 @@
 $url = 'https://github.com/gosddc/packer-post-processor-vagrant-vmware-ovf/releases/download/v0.2.1/packer-post-processor-vagrant-vmware-ovf.windows-i386.zip'
 $url64bit = 'https://github.com/gosddc/packer-post-processor-vagrant-vmware-ovf/releases/download/v0.2.1/packer-post-processor-vagrant-vmware-ovf.windows-amd64.zip'
-$unzipLocation = "$env:SystemDrive\HashiCorp\packer"
+$unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$legacyLocation = "$env:SystemDrive\HashiCorp\packer"
+$pluginExe = $legacyLocation + "\packer-post-processor-vagrant-vmware-ovf.exe"
 
 Install-ChocolateyZipPackage "packer-post-processor-vagrant-vmware-ovf" "$url" "$unzipLocation" "$url64bit"
-Install-ChocolateyPath $unzipLocation
+
+if (Test-Path $pluginExe) {
+  Write-Host "Removing old plugin from $legacyLocation"
+  Remove-Item $pluginExe
+}

--- a/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyInstall.ps1
+++ b/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $url = 'https://github.com/gosddc/packer-post-processor-vagrant-vmware-ovf/releases/download/v0.2.1/packer-post-processor-vagrant-vmware-ovf.windows-i386.zip'
 $url64bit = 'https://github.com/gosddc/packer-post-processor-vagrant-vmware-ovf/releases/download/v0.2.1/packer-post-processor-vagrant-vmware-ovf.windows-amd64.zip'
-$unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$unzipLocation = "${env:APPDATA}\packer.d\plugins"
 
 $legacyLocation = "$env:SystemDrive\HashiCorp\packer"
 $pluginExe = $legacyLocation + "\packer-post-processor-vagrant-vmware-ovf.exe"

--- a/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyUninstall.ps1
+++ b/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyUninstall.ps1
@@ -1,6 +1,0 @@
-$unzipLocation = "$env:SystemDrive\HashiCorp\packer"
-$pluginExe = $unzipLocation + "\packer-post-processor-vagrant-vmware-ovf.exe"
-
-if (Test-Path $pluginExe) {
-  Remove-Item $pluginExe
-}

--- a/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyUninstall.ps1
+++ b/packer-post-processor-vagrant-vmware-ovf/tools/chocolateyUninstall.ps1
@@ -1,0 +1,6 @@
+$unzipLocation = "${env:APPDATA}\packer.d\plugins"
+$pluginExe = $unzipLocation + "\packer-post-processor-vagrant-vmware-ovf.exe"
+
+if (Test-Path $pluginExe) {
+  Remove-Item $pluginExe
+}


### PR DESCRIPTION
I have seen that the https://chocolatey.org/packages/packer-windows-plugins installs all the packer plugins in `%APPDATA%/packer.d/plugins`.

So this packer plugin should go there as well.

The packer Chocolatey package itself will be installed in the Chocolatey package dir and no longer in C:/HashiCorp/packer to make install script easier and to support uninstall.

Packer plugins can't be installed in Chocolatey package dir as packer.exe itself would not find them as they are not side-by-side to packer.exe itself. So the APPDATA is a better place for them.
